### PR TITLE
Upgrade deprecated runtime nodejs14.x

### DIFF
--- a/amplify/backend/function/fillStaticThingGroup/fillStaticThingGroup-cloudformation-template.json
+++ b/amplify/backend/function/fillStaticThingGroup/fillStaticThingGroup-cloudformation-template.json
@@ -94,7 +94,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": "900"
       }

--- a/amplify/backend/function/job/job-cloudformation-template.json
+++ b/amplify/backend/function/job/job-cloudformation-template.json
@@ -100,7 +100,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": "900"
       }

--- a/amplify/backend/function/seedThings/seedThings-cloudformation-template.json
+++ b/amplify/backend/function/seedThings/seedThings-cloudformation-template.json
@@ -83,7 +83,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": "900"
       }


### PR DESCRIPTION
CloudFormation templates in iot-jobs-for-rapid-large-scale-device-updates have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs14.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.